### PR TITLE
Fix: Admin Asset Pack Regeneration 405 Error

### DIFF
--- a/apps/mighty-team-designs/src/components/admin/FlowDetailsModal.tsx
+++ b/apps/mighty-team-designs/src/components/admin/FlowDetailsModal.tsx
@@ -211,7 +211,7 @@ export function FlowDetailsModal({ flowId, isOpen, onClose }: FlowDetailsModalPr
       }
 
       // Call the asset pack generation API
-      const response = await fetch('/api/asset-packs', {
+      const response = await fetch('/api/asset-packs/generate', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',


### PR DESCRIPTION
## Problem
The admin flow UI was getting a 405 Method Not Allowed error when trying to regenerate asset packs on the deployed server.

## Root Cause
The admin UI was calling the wrong endpoint:
- ❌  (doesn't exist)
- ✅  (correct endpoint)

## Solution
Updated  to use the correct asset pack generation endpoint.

## Changes
- Fixed admin UI to call  instead of 
- Resolves 405 error when clicking 'Regenerate Asset Pack' in admin flow details
- No breaking changes, only endpoint correction

## Testing
- Admin asset pack regeneration should now work correctly on deployed server
- Local development remains unaffected